### PR TITLE
Rename /report (for back compat) to /api/old_format_reports...

### DIFF
--- a/lib/Perl5/CoreSmokeDB/API/FreeRoutes.pm
+++ b/lib/Perl5/CoreSmokeDB/API/FreeRoutes.pm
@@ -66,14 +66,19 @@ get '/api/openapi/web' => sub {
     return $yaml;
 };
 
-=head2 POST B</report>
+=head2 POST B</api/old_format_reports>
 
 This is a backward compatible endpoint that allows old clients to keep working.
 It uses the global variable C<$::web_api> to access the new API.
 
+Fastly CDN will redirect /report to /api/old_format_reports.
+
+We need `/api` in the path so the k8 Ingest knows to sent to the correct
+container.
+
 =cut
 
-post '/report' => sub {
+post '/api/old_format_reports' => sub {
     my $start = time();
     my $data = from_json(encode('utf-8', params->{json}), { utf8 => 1 });
 

--- a/t/150-post-report.t
+++ b/t/150-post-report.t
@@ -57,10 +57,10 @@ $schema->txn_do(
 
 $schema->txn_do(
     sub {
-        note("Backward compatibility: POST /report");
+        note("Backward compatibility: POST /api/old_format_reports");
         my $response = $tester->request(
             HTTP::Request->new(
-                POST => '/report',
+                POST => '/api/old_format_reports',
                 [ 'Content-type' => 'application/x-www-form-urlencoded' ],
                 join("=", map {uri_escape($_) } "json", $jsn_rpt)
             )


### PR DESCRIPTION
- /report is not just another name for /api/report is expects a different format payload

- So that we can get traffic to the API Container we need the end point under /api/.. (because of k8 Ingress rule)